### PR TITLE
revisão do monolith

### DIFF
--- a/T2/monolith/monolith.lua
+++ b/T2/monolith/monolith.lua
@@ -107,3 +107,5 @@ for _, v in ipairs(wordsFreqs) do
     end
     counter = counter + 1
 end
+
+-- ver comentarios em pull-request (Roxana)


### PR DESCRIPTION
O código não da os resultados esperados, vejam que o primeiro valor é -89

observações:
- não tem diagrama do estilo
- na linha 24 do código, as palavras do stopword são normalizadas (lowercase), não obstante, isto não é necessario para os stopwords (já estão em minuscula). A normalização é util quando a lista de stopwords é extendida com letras [a-z], para o qual se explicita que estas estejam em minuscula [linha 9](https://github.com/crista/exercises-in-programming-style/blob/master/03-monolith/tf-03.py).
- o código não cumpre a [regra 2](https://pes2006.wordpress.com/2006/03/15/disciplina/) da disciplina